### PR TITLE
extend ingress with optional config: spec.ingressClassName

### DIFF
--- a/charts/acend-training-chart/Chart.yaml
+++ b/charts/acend-training-chart/Chart.yaml
@@ -4,5 +4,5 @@ description: Deploy acend training pages
 type: application
 maintainers:
   - name: acend
-version: 0.1.8
+version: 0.1.9
 appVersion: 1.0.0

--- a/charts/acend-training-chart/templates/ingress.yaml
+++ b/charts/acend-training-chart/templates/ingress.yaml
@@ -30,6 +30,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  {{- if .ingress.ingressClassName }}
+  ingressClassName: {{ .ingress.ingressClassName}}
+  {{- end }}
   tls:
     {{- if .ingress.emptyTLS }}
     - {}

--- a/charts/acend-training-chart/values.yaml
+++ b/charts/acend-training-chart/values.yaml
@@ -37,10 +37,10 @@ acendTraining:
       ingress:
         annotations:
           kubernetes.io/tls-acme: "true"
-        ingressClassName: nginx-public
+        # ingressClassName: nginx
         useDefaultSecret: true
         appname: hugo-training-template
-        domain: puzzle.ch
+        domain: training.acend.ch
         # domainmain: puzzle.ch
 
 nameOverride: ""

--- a/charts/acend-training-chart/values.yaml
+++ b/charts/acend-training-chart/values.yaml
@@ -36,11 +36,11 @@ acendTraining:
       podAnnotations: {}
       ingress:
         annotations:
-          kubernetes.io/ingress.class: nginx-public
           kubernetes.io/tls-acme: "true"
+        ingressClassName: nginx-public
         useDefaultSecret: true
         appname: hugo-training-template
-        domain: k8s.puzzle.ch
+        domain: puzzle.ch
         # domainmain: puzzle.ch
 
 nameOverride: ""


### PR DESCRIPTION
Ingress` spec.ingressClassName` can be defined inside a deployment in the values.yaml file by setting `ingress.ingressClassName`.

This is optional and should not affect existing deployments.