### PR TITLE
Fix incorrect relabel target

### DIFF
--- a/charts/uptime-dashboard/Chart.yaml
+++ b/charts/uptime-dashboard/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: uptime-dashboard
 description: Deplay a Grafana dashboard to monitor application uptime
 type: application
-version: 0.1.0
+version: 0.1.1
 maintainers:
   - name: acend
 appVersion: "1.16.0"

--- a/charts/uptime-dashboard/templates/configmap-prometheus.yaml
+++ b/charts/uptime-dashboard/templates/configmap-prometheus.yaml
@@ -39,7 +39,7 @@ data:
         - source_labels: [__param_target]
           target_label: instance
         - target_label: __address__
-          replacement: acend-ocp-uptime-monitoring-prometheus-blackbox-exporter:9115
+          replacement: {{ .Release.Name }}-prometheus-blackbox-exporter:9115
 
     alerting:
       alertmanagers:


### PR DESCRIPTION
The blackbox exporter service has the address `{{ .Release.Name }}-prometheu-blackbox-exporter:9115` and should not be hard coded.

See: [upstream helm chart](https://github.com/prometheus-community/helm-charts/blob/23e62ec1bce625e937648cded9a2c1dedd587e29/charts/prometheus-blackbox-exporter/templates/service.yaml#L8)
